### PR TITLE
Add a buildArg -march=compatibility to allow running on older...

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -68,19 +68,23 @@
             <plugin>
                 <groupId>org.graalvm.buildtools</groupId>
                 <artifactId>native-maven-plugin</artifactId>
-                <!--
-                    Static linking and musl is not supported
-                    on arm64 yet
-                    @see https://www.graalvm.org/latest/reference-manual/native-image/metadata/Compatibility/
-                -->
-                <!--
                 <configuration>
                     <buildArgs>
+                        <!--
+                            Static linking and musl is not supported
+                            on arm64 yet
+                            @see https://www.graalvm.org/latest/reference-manual/native-image/metadata/Compatibility/
+                        -->
+                        <!--
                         <arg>- -static</arg>
                         <arg>- -libc=musl</arg>
+                        -->
+                        <!--
+                            Build for compatibility, allowing image to run on architectures older than the build machine.
+                        -->
+                        <buildArg>-march=compatibility</buildArg>
                     </buildArgs>
                 </configuration>
-                -->
             </plugin>
             <plugin>
                 <groupId>org.springframework.boot</groupId>


### PR DESCRIPTION
architectures than the build machine.

For me this fixes issue #166 

With this change I see among the build output:

```
#10 31.96  Graal compiler: optimization level: 2, target machine: compatibility
```

and I no longer see any message about an architecture fallback (which happens on my machine, but may not on others), as mentioned in #166.

