### PR TITLE
Query multiple IPs via POST JSON array

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,48 @@ X-Geoip-Continent: EU
 X-Geoip-Timezone: Europe/Berlin
 ```
 
+### Querying multiple IPs via POST
+
+```bash
+curl --location 'http://localhost:8080/' \
+--header 'Content-Type: application/json' \
+--data '[
+    "8.8.8.8",
+    "8.8.4.4"
+]'
+
+{
+  "8.8.4.4": {
+    "country":"US",
+    "latitude":"37.751",
+    "longitude":"-97.822",
+    "continent":"NA",
+    "timezone":"America/Chicago",
+    "accuracyRadius":1000,
+    "asn":15169,
+    "asnOrganization":"GOOGLE",
+    "asnNetwork":"8.8.4.0/24"
+  },
+  "8.8.8.8": {
+    "country":"US",
+    "latitude":"37.751",
+    "longitude":"-97.822",
+    "continent":"NA",
+    "timezone":"America/Chicago",
+    "accuracyRadius":1000,
+    "asn":15169,
+    "asnOrganization":"GOOGLE",
+    "asnNetwork":"8.8.8.0/24"
+  }
+}
+```
+
+Takes up to 100 addresses at once.
+
+Result will be a JSON object indexed by requested IP address.
+
+If a requested address can not be resolved, the entry will be missing in the response.
+
 ## 📦 Building the project
 
 The project is built through multi stage Docker builds. You need

--- a/src/main/java/org/observabilitystack/geoip/web/TooManyAddressesException.java
+++ b/src/main/java/org/observabilitystack/geoip/web/TooManyAddressesException.java
@@ -1,0 +1,9 @@
+package org.observabilitystack.geoip.web;
+
+public class TooManyAddressesException extends RuntimeException {
+	private static final long serialVersionUID = 742704466635106825L;
+
+	public TooManyAddressesException(String message) {
+        super(message);
+    }
+}

--- a/src/test/java/org/observabilitystack/geoip/web/GeoIpRestControllerTest.java
+++ b/src/test/java/org/observabilitystack/geoip/web/GeoIpRestControllerTest.java
@@ -4,7 +4,9 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import java.net.InetAddress;
@@ -23,6 +25,8 @@ import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 public class GeoIpRestControllerTest {
 
     private static final InetAddress IPV4_ADDR = InetAddresses.forString("192.168.1.1");
+    private static final InetAddress IPV4_ADDR2 = InetAddresses.forString("172.16.0.1");
+    private static final InetAddress IPV4_ADDR3 = InetAddresses.forString("10.0.0.1");
     private static final InetAddress IPV6_ADDR = InetAddresses.forString("2001:db8:1::1");
 
     private MockMvc mockMvc;
@@ -33,6 +37,8 @@ public class GeoIpRestControllerTest {
     public void setUp() {
         provider = mock(GeolocationProvider.class);
         when(provider.lookup(eq(IPV4_ADDR))).thenReturn(Optional.of(GeoIpEntry.builder().setCountry("ZZ").build()));
+        when(provider.lookup(eq(IPV4_ADDR2))).thenReturn(Optional.of(GeoIpEntry.builder().setCountry("ZZ").build()));
+        when(provider.lookup(eq(IPV4_ADDR3))).thenReturn(Optional.of(GeoIpEntry.builder().setCountry("ZZ").build()));
         when(provider.lookup(eq(IPV6_ADDR))).thenReturn(Optional.of(GeoIpEntry.builder().setCountry("ZZ").build()));
         restController = new GeoIpRestController(provider);
         mockMvc = MockMvcBuilders.standaloneSetup(restController).build();
@@ -57,6 +63,45 @@ public class GeoIpRestControllerTest {
                 .andExpect(status().isOk())
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON_VALUE))
                 .andExpect(content().json("{\"country\":\"ZZ\"}"));
+    }
+    
+    @Test
+    public void testMultiIpv4Addresses() throws Exception {
+    	mockMvc.perform(post("/").contentType(MediaType.APPLICATION_JSON).content(
+    			"[\"" + 
+    			IPV4_ADDR.getHostAddress() + 
+    			"\", \"" + 
+    			IPV4_ADDR2.getHostAddress() + 
+    			"\", \"" + 
+    			IPV4_ADDR3.getHostAddress() + 
+    			"\"]"
+    		))
+    		.andExpect(status().isOk())
+    		.andExpect(content().contentType(MediaType.APPLICATION_JSON))
+    		.andExpect(jsonPath("$[\"" + IPV4_ADDR.getHostAddress() + "\"].country").value("ZZ"))
+    		.andExpect(jsonPath("$[\"" + IPV4_ADDR2.getHostAddress() + "\"].country").value("ZZ"))
+    		.andExpect(jsonPath("$[\"" + IPV4_ADDR3.getHostAddress() + "\"].country").value("ZZ"));
+    }
+    
+    @Test
+    public void testMultiIpv4AddressesExceedingLimit() throws Exception {
+        InetAddress[] ipAddresses = new InetAddress[101];
+        for (int i = 0; i < 101; i++) {
+            ipAddresses[i] = InetAddress.getByName("192.168.1." + i);
+        }
+
+        String jsonContent = "[";
+        for (InetAddress address : ipAddresses) {
+            jsonContent += "\"" + address.getHostAddress() + "\",";
+        }
+        jsonContent = jsonContent.substring(0, jsonContent.length() - 1) + "]";
+
+        mockMvc.perform(post("/")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(jsonContent))
+                .andExpect(status().isBadRequest())
+                .andExpect(content().contentType("text/plain;charset=ISO-8859-1"))
+                .andExpect(content().string("Only 100 address requests allowed at once"));
     }
 
     @Test


### PR DESCRIPTION
I added a new endpoint for querying up to 100 IP addresses at once in the form of a JSON string array.
Endpoint responds with a `Map<String(IP), GeoIpEntry>`.

This performs a bit better than single http requests for each of 100 addresses.