### PR TITLE
Fix nginx-geoip docker-compose

### DIFF
--- a/examples/nginx-geoip/docker-compose.yaml
+++ b/examples/nginx-geoip/docker-compose.yaml
@@ -4,7 +4,7 @@ version: '2.4'
 
 services:
   geoip:
-    image: geoip-api:latest
+    image: ghcr.io/observabilitystack/geoip-api:latest
     ports:
       - 8081:8080
 


### PR DESCRIPTION
the docker compose file is failing
due to wrong container image and it
is fixed in this patch.